### PR TITLE
Fix GCC 7.1.1 error when converting std::function to function pointer.

### DIFF
--- a/src/AudioDevice.cpp
+++ b/src/AudioDevice.cpp
@@ -266,7 +266,9 @@ void AudioDevice::setHaltChannelCallback(
 {
   d_halt_channel_callback = callback;
 
-  Mix_ChannelFinished( *d_halt_channel_callback.target<void(int)>() );
+
+  typedef void function_t(int);
+  Mix_ChannelFinished( *d_halt_channel_callback.target<function_t*>() );
 }
 
 // Play a mix chunk
@@ -415,7 +417,8 @@ void AudioDevice::setHaltMusicCallback( std::function<void(void)>& callback )
 {
   d_halt_music_callback = callback;
 
-  Mix_HookMusicFinished( *d_halt_music_callback.target<void(void)>() );
+  typedef void function_t(void);
+  Mix_HookMusicFinished( *d_halt_music_callback.target<function_t*>() );
 }
 
 // Stop the custom music player (haltMusic will not work)


### PR DESCRIPTION
Original error message follows.

    [ 12%] Building CXX object src/CMakeFiles/qtd1_core.dir/AudioDevice.cpp.o
    In file included from /usr/include/c++/7.1.1/functional:58:0,
                     from /home/u/Desktop/qtd1/QtD1/src/AudioDevice.h:14,
                     from /home/u/Desktop/qtd1/QtD1/src/AudioDevice.cpp:10:
    /usr/include/c++/7.1.1/bits/std_function.h: In instantiation of ‘_Functor* std::function<_Res(_ArgTypes ...)>::target() [with _Functor = void(int); _Res = void; _ArgTypes = {int}]’:
    /home/u/Desktop/qtd1/QtD1/src/AudioDevice.cpp:269:67:   required from here
    /usr/include/c++/7.1.1/bits/std_function.h:733:9: error: invalid use of const_cast with type ‘void (*)(int)’, which is a pointer or reference to a function type
      return const_cast<_Functor*>(__func);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /usr/include/c++/7.1.1/bits/std_function.h: In instantiation of ‘_Functor* std::function<_Res(_ArgTypes ...)>::target() [with _Functor = void(); _Res = void; _ArgTypes = {}]’:
    /home/u/Desktop/qtd1/QtD1/src/AudioDevice.cpp:418:68:   required from here
    /usr/include/c++/7.1.1/bits/std_function.h:733:9: error: invalid use of const_cast with type ‘void (*)()’, which is a pointer or reference to a function type
    make[2]: *** [src/CMakeFiles/qtd1_core.dir/build.make:615: src/CMakeFiles/qtd1_core.dir/AudioDevice.cpp.o] Error 1
    make[1]: *** [CMakeFiles/Makefile2:183: src/CMakeFiles/qtd1_core.dir/all] Error 2
    make: *** [Makefile:141: all] Error 2